### PR TITLE
Ligurio/enable centipede

### DIFF
--- a/projects/helm/Dockerfile
+++ b/projects/helm/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/helm/helm
-RUN git clone --depth 1 --branch=helmfixnative https://github.com/AdamKorcz/cncf-fuzzing
+RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 COPY build.sh $SRC/
 WORKDIR $SRC/helm

--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -39,6 +39,12 @@ cd $SRC/tarantool
 # not unused, but the compilers are complaining.
 sed -i 's/total = 0;/total = 0;(void)total;/g' ./src/lib/core/crash.c
 sed -i 's/n = 0;/n = 0;(void)n;/g' ./src/lib/core/sio.c
+if [[ $FUZZING_ENGINE == centipede ]]
+then
+    sed -i \
+        '/$ENV{LIB_FUZZING_ENGINE}/a \ \ \ \ \ \ \ \ -lc++' \
+        test/fuzz/CMakeLists.txt
+fi
 
 case $SANITIZER in
   address) SANITIZERS_ARGS="-DENABLE_ASAN=ON" ;;

--- a/projects/tarantool/project.yaml
+++ b/projects/tarantool/project.yaml
@@ -8,6 +8,7 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - honggfuzz
+  - centipede
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Fixing `Centipede`'s compatibility issue with `tarantool`.